### PR TITLE
[#166777228] html string support in pref.description

### DIFF
--- a/app/assets/javascripts/listings/components/listing/eligibility-section.html.slim
+++ b/app/assets/javascripts/listings/components/listing/eligibility-section.html.slim
@@ -115,8 +115,7 @@ accordion-heading.lead
                 | Up to {{preference.unitsAvailable}} units available
               p.c-steel ng-if="!preference.unitsAvailable"
                 | All remaining units
-            p.c-steel
-              | {{preference.description}}
+            p.c-steel ng-text-truncate="::preference.description" ng-tt-words-threshold="999"
               br
               a.margin-right ng-href="{{preference.readMoreUrl}}" target="_blank" ng-if="preference.readMoreUrl"
                 | Read More


### PR DESCRIPTION
Slightly hacked in, but it's 100% unclear to me why slim isn't just doing unescaped HTML with {{}} and this seemed like the least intrusive way to work around it.