### PR TITLE
remove conditional and always show additional opptys on welcome

### DIFF
--- a/app/assets/javascripts/listings/components/welcome-component.html.slim
+++ b/app/assets/javascripts/listings/components/welcome-component.html.slim
@@ -13,13 +13,8 @@ section.splash-header.bg-image
 
 .row.welcome-secondary-banner
   .columns
-    .welcome-block.text-center ng-if="$ctrl.parent.openListings.length == 0"
+    .welcome-block.text-center
       h2.delta.t-alt-sans.c-oil
         | {{'LISTINGS.VIEW_ADDITIONAL_HOUSING_OPPORTUNITIES_HEADER' | translate}}
       a.button.radius.margin-bottom-none ui-sref="dahlia.additional-resources"
         | {{'LISTINGS.VIEW_ADDITIONAL_HOUSING_OPPORTUNITIES_BUTTON' | translate}}
-    .welcome-block.text-center ng-if="$ctrl.parent.openListings.length > 0"
-      h2.delta.t-alt-sans.c-oil
-        | {{'WELCOME.SHARED_HOUSING' | translate}}
-      a.button.radius.margin-bottom-none href="{{'WELCOME.SHARED_HOUSING_LINK' | translate}}"
-        | {{'WELCOME.SHARED_HOUSING_BUTTON' | translate}}


### PR DESCRIPTION
Now the welcome screen shows the Additional Housing Opportunities button full time, and shared housing is no longer shown, per request from @slowbot.