### PR TITLE
Convert monthly rent to int in unit summary #167584018

### DIFF
--- a/app/services/unit_service.rb
+++ b/app/services/unit_service.rb
@@ -11,7 +11,7 @@ class UnitService
           units,
           :monthly_rent_as_percent_of_income,
         ),
-        rent_range: min_max_range(units, :monthly_rent),
+        rent_range: monthly_rent_range(units),
         unit_type: I18n.t("unit_types.#{unit_type}"),
       }
     end
@@ -32,6 +32,13 @@ class UnitService
       min_occupancy = units.map(&:min_occupancy).min
       max_occupancy = units.map(&:max_occupancy).max
       { min: min_occupancy, max: max_occupancy }
+    end
+
+    def monthly_rent_range(units)
+      range = min_max_range(units, :monthly_rent)
+      range[:min] = range[:min]&.to_i
+      range[:max] = range[:max]&.to_i
+      range
     end
   end
 end


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/167584018

The monthly rent is a decimal in the DB, so when it gets converted to JSON it gets represented as a string instead of a number. This was causing problems with our display of the unit monthly rent range on the listings page. The rents on all current SMC and SJ units are integers, and we never display a monthly rent figure as a float in the listings site frontend, so doing integer conversion of the monthly rents before sending to the frontend is fine. We should revisit all listing field types in our renovation work.